### PR TITLE
Explicitly use python 2 in shebang, fixes #3

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Copyright (c) 2009 Google Inc. All rights reserved.
 #


### PR DESCRIPTION
Sadly `cpplint.py` is pretty horrendously maintained so we can't just update to a newer version