### PR TITLE
CMakeLists.txt: download submodules if needed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,10 +70,10 @@ endif()
 
 # Download submodules if needed
 
-if(NOT EXISTS ${CMAKE_SOURCE_DIR}/src/configparser/CMakeLists.txt OR NOT EXISTS ${CMAKE_SOURCE_DIR}/src/cppgtfs/CMakeLists.txt OR NOT EXISTS ${CMAKE_SOURCE_DIR}/src/xml/pfxml.h)
-        execute_process(
-                COMMAND git submodule update --init --recursive
-        )
+if(NOT EXISTS ${CMAKE_SOURCE_DIR}/src/configparser/.git OR NOT EXISTS ${CMAKE_SOURCE_DIR}/src/cppgtfs/.git OR NOT EXISTS ${CMAKE_SOURCE_DIR}/src/xml/.git)
+    execute_process(
+        COMMAND git submodule update --init --recursive
+    )
 endif()
 
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,14 @@ else()
 	set(VERSION_GIT_FULL "${VERSION_GIT}-${VERSION_GIT_IS_DIRTY}")
 endif()
 
+# Download submodules if needed
+
+if(NOT EXISTS ${CMAKE_SOURCE_DIR}/src/configparser/CMakeLists.txt OR NOT EXISTS ${CMAKE_SOURCE_DIR}/src/cppgtfs/CMakeLists.txt)
+        execute_process(
+                COMMAND git submodule update --init --recursive
+        )
+endif()
+
 add_subdirectory(src)
 
 # tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ endif()
 
 # Download submodules if needed
 
-if(NOT EXISTS ${CMAKE_SOURCE_DIR}/src/configparser/CMakeLists.txt OR NOT EXISTS ${CMAKE_SOURCE_DIR}/src/cppgtfs/CMakeLists.txt)
+if(NOT EXISTS ${CMAKE_SOURCE_DIR}/src/configparser/CMakeLists.txt OR NOT EXISTS ${CMAKE_SOURCE_DIR}/src/cppgtfs/CMakeLists.txt OR NOT EXISTS ${CMAKE_SOURCE_DIR}/src/xml/pfxml.h)
         execute_process(
                 COMMAND git submodule update --init --recursive
         )


### PR DESCRIPTION
Download git submodules if the CMakeLists.txt files for the configparser or cppgtfs directories are not present.

cf. https://stackoverflow.com/questions/60126203/how-do-i-get-cmake-to-find-openmp-c-openmp-cxx-etc/60136444#60136444