### PR TITLE
Fix edge splitting fragment ending up with wrong geometry in edge grid

### DIFF
--- a/src/pfaedle/osm/OsmBuilder.cpp
+++ b/src/pfaedle/osm/OsmBuilder.cpp
@@ -1357,7 +1357,7 @@ std::set<Node*> OsmBuilder::snapStation(Graph* g, NodePL* s, EdgeGrid* eg,
         ll.push_back(*n->pl().getGeom());
         ll.push_back(*e->getTo()->pl().getGeom());
         *nf->pl().getGeom() = ll;
-        eg->add(l, nf);
+        eg->add(ll, nf);
 
         // replace edge in restrictor
         restor->replaceEdge(e, ne, nf);


### PR DESCRIPTION
If I'm not mistaken, there is a typo in the OsmBuilder when an edge is split into two edges to insert a station: one of the new edges is registered with the wrong geometry in the edge grid. This should fix it.