### PR TITLE
let Travis CI build & publish Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 /build
 
 /Dockerfile
+/push-docker-image.sh

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+/build
+
+/Dockerfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,13 @@ before_script:
 script:
   - make -j4
   - ctest --verbose
+  - docker build -t ad-freiburg/pfaedle .
+
+deploy:
+  on:
+    branch: master
+  provider: script
+  script: bash push-docker-image.sh
 
 notifications:
   email:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM debian:buster-slim AS builder
+
+WORKDIR /app
+
+RUN apt-get update && \
+	apt-get install -y g++ cmake git
+
+ADD . /app
+RUN mkdir build && \
+	cd build && \
+	cmake .. && \
+	make -j && \
+	pwd && \
+	make install
+
+FROM debian:buster-slim
+
+RUN apt-get update && \
+	apt-get install -y libgomp1 && \
+	rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/local/etc/pfaedle /usr/local/etc/pfaedle
+COPY --from=builder /usr/local/bin/pfaedle /usr/local/bin/pfaedle
+
+ENTRYPOINT ["/usr/local/bin/pfaedle"]

--- a/README.md
+++ b/README.md
@@ -75,6 +75,20 @@ input GTFS feed and the input configuration.
 This can be used to avoid parsing (for example) the entire `planet.osm` on each
 run.
 
+## via Docker
+
+You can use the [`ad-freiburg/pfaedle` Docker image](https://hub.docker.com/repository/docker/ad-freiburg/pfaedle) by mounting the OSM & GTFS data into the container:
+
+```shell
+docker run -i --rm \
+	# mount OSM data
+	--volume /path/to/osm/data:/osm \
+	# mount GTFS data
+	--volume /path/to/gtfs/data:/gtfs \
+	# tell pfaedle where to find the data
+	pfaedle -x /osm/osm-data.xml -i /gtfs
+```
+
 ## Debugging
 
 The following flags may be useful for debugging:

--- a/push-docker-image.sh
+++ b/push-docker-image.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -ex
+set -o pipefail
+
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+docker push ad-freiburg/pfaedle


### PR DESCRIPTION
Still left to do:

- [x] Document that the Docker image is available and how to use it.
- [ ] Add the `DOCKER_USERNAME` & `DOCKER_PASSWORD` environment variables to the Travis CI project.

closes #16