### PR TITLE
fixed small inconsistency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ docker run -i --rm \
 	# mount GTFS data
 	--volume /path/to/gtfs/data:/gtfs \
 	# tell pfaedle where to find the data
-	pfaedle -x /osm/osm-data.xml -i /gtfs
+	adfreiburg/pfaedle -x /osm/osm-data.xml -i /gtfs
 ```
 
 ## Debugging


### PR DESCRIPTION
The docker section in the README suggests using the `adfreiburg/docker` image. But the following example does not use this image. This merge request fixes that.