### PR TITLE
Automatically publish container image to Github Container Repo

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,43 @@
+name: "Container image build"
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+
+  image:
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.ref == 'refs/heads/master' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -33,6 +33,9 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value={{date 'YYYY-MM-DDTHH-mm'}}
+            type=raw,value=latest
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim AS builder
+FROM debian:bookworm-slim AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
This PR adds automatic publishing of a container image to GCR, which means that you don't need to set up any authentication and Github Actions takes care of everything.

The result looks like this: https://github.com/leonardehrenfried/pfaedle/pkgs/container/pfaedle

I've chosen to use both a date-based tag as well as "latest".

Thanks for this great piece of software!