### PR TITLE
enforce signed char compiler flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 set(EXECUTABLE_OUTPUT_PATH "${CMAKE_BINARY_DIR}")
 
 # set compiler flags, see http://stackoverflow.com/questions/7724569/debug-vs-release-in-cmake
-set(CMAKE_CXX_FLAGS                "-Ofast -fno-signed-zeros -fno-trapping-math -Wall -Wno-format-extra-args -Wextra -Wformat-nonliteral -Wformat-security -Wformat=2 -Wextra -Wno-implicit-fallthrough -pedantic -Wno-keyword-macro")
+set(CMAKE_CXX_FLAGS                "-Ofast -fsigned-char -fno-signed-zeros -fno-trapping-math -Wall -Wno-format-extra-args -Wextra -Wformat-nonliteral -Wformat-security -Wformat=2 -Wextra -Wno-implicit-fallthrough -pedantic -Wno-keyword-macro")
 set(CMAKE_CXX_FLAGS_SANITIZE       "-Og -g -fsanitize=address -fsanitize=leak -fsanitize=undefined -DLOGLEVEL=3 -DPFAEDLE_DBG=1")
 set(CMAKE_CXX_FLAGS_PROFILE        "-g -pg -DLOGLEVEL=3 -DPFAEDLE_DBG=1")
 set(CMAKE_CXX_FLAGS_DEBUG          "-Og -g -DLOGLEVEL=3 -DPFAEDLE_DBG=1")


### PR DESCRIPTION
Fixes using the program on Linux arm64 by forcing signed chars to be used.
Otherwise, arguments/CSV/JSON parsing are all impossible which makes using the program unusable.

```
/***/pfaedle/src/util/String.h: In function ‘std::string util::jsonStringEscape(const string&)’:
/***/pfaedle/src/util/String.h:84:20: warning: comparison is always true due to limited range of data type [-Wtype-limits]
   84 |         if ('\x00' <= *c && *c <= '\x1f') {
      |             ~~~~~~~^~~~~
```

```
/***/pfaedle/src/cppgtfs/src/ad/util/CsvParser.cpp:90:38: warning: comparison is always false due to limited range of data type [-Wtype-limits]
   90 |       static_cast<int>(_buff[s + 2]) == -65) {
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
```

```
/***/pfaedle/src/pfaedle/config/ConfigReader.cpp: In static member function ‘static void pfaedle::config::ConfigReader::read(pfaedle::config::Config*, int, char**)’:
/***/pfaedle/src/pfaedle/config/ConfigReader.cpp:151:78: warning: comparison is always true due to limited range of data type [-Wtype-limits]
  151 |   while ((c = getopt_long(argc, argv, ":o:hvi:c:x:Dm:g:X:T:d:pP:F", ops, 0)) !=
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
  152 |          -1) {
      |          ~~
```