### PR TITLE
Update minimum cmake version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.1)
+cmake_minimum_required (VERSION 3.5)
 set(CMAKE_CXX_STANDARD 11)
 
 project (pfaedle)


### PR DESCRIPTION
CMake as deprecated backwards compatibility for cmake versions `< 3.5`:

```zsh
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```

I'm not sure why you set it so low, so I only increased it to the minimum supported version.