### PR TITLE
fix: add railway=rail and railway=narrow_gauge to tram/subway OSM filter

### DIFF
--- a/pfaedle.cfg
+++ b/pfaedle.cfg
@@ -1195,7 +1195,6 @@ osm_filter_lvl3:
 	route=tram
 	route=narrow_gauge
 	railway=subway
-	railway=rail
 	railway=narrow_gauge
 	railway=light_rail
 	railway=tram

--- a/pfaedle.cfg
+++ b/pfaedle.cfg
@@ -887,6 +887,7 @@ osm_filter_keep:
 	railway=subway
 	railway=light_rail
 	railway=tram
+	railway=narrow_gauge
 	railway=funicular
 	railway=station
 	railway=halt

--- a/pfaedle.cfg
+++ b/pfaedle.cfg
@@ -885,6 +885,7 @@ osm_filter_keep:
 	route=tram
 	route=funicular
 	railway=subway
+	railway=rail
 	railway=light_rail
 	railway=tram
 	railway=narrow_gauge
@@ -1194,6 +1195,7 @@ osm_filter_lvl3:
 	route=tram
 	route=narrow_gauge
 	railway=subway
+	railway=rail
 	railway=narrow_gauge
 	railway=light_rail
 	railway=tram


### PR DESCRIPTION
## Problem

The `[tram, subway]` section in `pfaedle.cfg` does not include `railway=rail` or `railway=narrow_gauge` in its `osm_filter_keep` list. 
This is an issue in Stockholm where several GTFS "trams" are on tracks marked with narrow_gauge or simply rail.

### Examples
* **`railway=rail` for Saltsjöbanan:** https://www.openstreetmap.org/way/201418881
* **`railway=narrow_gauge` on Roslagsbanan:** https://www.openstreetmap.org/relation/241405

Both of them are marked as "tram" in the GTFS feeds: `route_type = 900`

## Fix
Add `railway=rail` and `railway=narrow_gauge` to `osm_filter_keep` in the `[tram, subway]` section:

